### PR TITLE
Finish rebranding, update to latest MAPI, leverage new MAPI features

### DIFF
--- a/CMS/CMSModules/Kentico.KontentPublishing/Pages/Sync.aspx
+++ b/CMS/CMSModules/Kentico.KontentPublishing/Pages/Sync.aspx
@@ -21,7 +21,7 @@
             <cms:LocalizedButton ID="btnSyncAttachments" runat="server" OnClick="btnSyncAttachments_Click" EnableViewState="false" Text="Synchronize attachments" ButtonStyle="Default" />
             <cms:LocalizedButton ID="btnSyncLanguages" runat="server" OnClick="btnSyncLanguages_Click" EnableViewState="false" Text="Synchronize cultures" ButtonStyle="Default" />
             <cms:LocalizedButton ID="btnSyncPages" runat="server" OnClick="btnSyncPages_Click" EnableViewState="false" Text="Synchronize pages" ButtonStyle="Default" />
-            <cms:LocalizedButton ID="btnDeleteAll" runat="server" OnClick="btnDeleteAll_Click" EnableViewState="false" Text="Delete all data in Kentico Cloud" ButtonStyle="Default" OnClientClick="return confirm('This will delete all data in the target Kentico Cloud project, not only the data synchronized from this site. Are you sure you want to continue?')" />
+            <cms:LocalizedButton ID="btnDeleteAll" runat="server" OnClick="btnDeleteAll_Click" EnableViewState="false" Text="Delete all data in Kentico Kontent" ButtonStyle="Default" OnClientClick="return confirm('This will delete all data in the target Kentico Cloud project, not only the data synchronized from this site. Are you sure you want to continue?')" />
         </asp:PlaceHolder>
     </asp:PlaceHolder>
 </asp:Content>

--- a/CMS/CMSModules/Kentico.KontentPublishing/Pages/Sync.aspx
+++ b/CMS/CMSModules/Kentico.KontentPublishing/Pages/Sync.aspx
@@ -15,6 +15,10 @@
         <cms:LocalizedButton runat="server" ID="btnDangerZone" OnClick="btnDangerZone_Click" Text="Show advanced actions" ButtonStyle="Default" />
         <asp:Panel runat="server" ID="pnlDangerZone" Visible="false">
             <br />
+            <cms:LocalizedButton ID="btnDeleteAll" runat="server" OnClick="btnDeleteAll_Click" EnableViewState="false" Text="Delete all data in Kentico Kontent" ButtonStyle="Default" OnClientClick="return confirm('This will delete all data in the target Kentico Cloud project, not only the data synchronized from this site. Are you sure you want to continue?')" />
+            <br /><br />
+            <h4>Granular sync to Kontent</h4>
+            <p>Execute in the defined order after deleting all. Some stages can be re-synced individually unless there is a strong reference from later object types.</p>
             <cms:LocalizedButton ID="btnSyncMediaLibraries" runat="server" OnClick="btnSyncMediaLibraries_Click" EnableViewState="false" Text="Synchronize media libraries" ButtonStyle="Default" />
             <br /><br />
             <cms:LocalizedButton ID="btnSyncRelationships" runat="server" OnClick="btnSyncRelationships_Click" EnableViewState="false" Text="Synchronize relationships" ButtonStyle="Default" />
@@ -29,7 +33,16 @@
             <br /><br />
             <cms:LocalizedButton ID="btnSyncPages" runat="server" OnClick="btnSyncPages_Click" EnableViewState="false" Text="Synchronize pages" ButtonStyle="Default" />
             <br /><br />
-            <cms:LocalizedButton ID="btnDeleteAll" runat="server" OnClick="btnDeleteAll_Click" EnableViewState="false" Text="Delete all data in Kentico Kontent" ButtonStyle="Default" OnClientClick="return confirm('This will delete all data in the target Kentico Cloud project, not only the data synchronized from this site. Are you sure you want to continue?')" />
+            <h4>Granular cleanup in Kontent</h4>
+            <p>Execute in the defined order, some actions may not succeed when previous data was not deleted due to references to previous object types.</p>
+            <cms:LocalizedButton ID="btnDeleteItems" runat="server" OnClick="btnDeleteItems_Click" EnableViewState="false" Text="Delete content items" ButtonStyle="Default" />
+            <br /><br />
+            <cms:LocalizedButton ID="btnDeleteContentTypes" runat="server" OnClick="btnDeleteContentTypes_Click" EnableViewState="false" Text="Delete content types" ButtonStyle="Default" />
+            <br /><br />
+            <cms:LocalizedButton ID="btnDeleteSnippets" runat="server" OnClick="btnDeleteSnippets_Click" EnableViewState="false" Text="Delete content type snippets" ButtonStyle="Default" />
+            <br /><br />
+            <cms:LocalizedButton ID="btnDeleteAssets" runat="server" OnClick="btnDeleteAssets_Click" EnableViewState="false" Text="Delete assets" ButtonStyle="Default" />
+            <br /><br />
         </asp:Panel>
     </asp:PlaceHolder>
 </asp:Content>

--- a/CMS/CMSModules/Kentico.KontentPublishing/Pages/Sync.aspx
+++ b/CMS/CMSModules/Kentico.KontentPublishing/Pages/Sync.aspx
@@ -1,5 +1,5 @@
 ﻿<%@ Page Language="C#" AutoEventWireup="true" Inherits="CMSModules_Kentico_KontentPublishing_Pages_Sync"
-    Theme="Default" MasterPageFile="~/CMSMasterPages/UI/SimplePage.master" Title="Kentico Cloud Publishing" CodeBehind="Sync.aspx.cs" %>
+    Theme="Default" MasterPageFile="~/CMSMasterPages/UI/SimplePage.master" Title="Kentico Kontent Publishing" CodeBehind="Sync.aspx.cs" %>
 
 <%@ Register Src="~/CMSAdminControls/AsyncLogDialog.ascx" TagName="AsyncLog"
     TagPrefix="cms" %>
@@ -15,7 +15,7 @@
         <cms:LocalizedButton runat="server" ID="btnDangerZone" OnClick="btnDangerZone_Click" Text="Show advanced actions" ButtonStyle="Default" />
         <asp:Panel runat="server" ID="pnlDangerZone" Visible="false">
             <br />
-            <cms:LocalizedButton ID="btnDeleteAll" runat="server" OnClick="btnDeleteAll_Click" EnableViewState="false" Text="Delete all data in Kentico Kontent" ButtonStyle="Default" OnClientClick="return confirm('This will delete all data in the target Kentico Cloud project, not only the data synchronized from this site. Are you sure you want to continue?')" />
+            <cms:LocalizedButton ID="btnDeleteAll" runat="server" OnClick="btnDeleteAll_Click" EnableViewState="false" Text="Delete all data in Kentico Kontent" ButtonStyle="Default" OnClientClick="return confirm('This will delete all data in the target Kentico Kontent project, not only the data synchronized from this site. Are you sure you want to continue?')" />
             <br /><br />
             <h4>Granular sync to Kontent</h4>
             <p>Execute in the defined order after deleting all. Some stages can be re-synced individually unless there is a strong reference from later object types.</p>

--- a/CMS/CMSModules/Kentico.KontentPublishing/Pages/Sync.aspx
+++ b/CMS/CMSModules/Kentico.KontentPublishing/Pages/Sync.aspx
@@ -10,18 +10,26 @@
     </asp:Panel>
 </asp:Content>
 <asp:Content ContentPlaceHolderID="plcContent" runat="server">
-    <asp:PlaceHolder runat="server" ID="plcTextBox">
+    <asp:PlaceHolder runat="server" ID="plcSync">
         <cms:LocalizedButton ID="btnSyncAll" runat="server" OnClick="btnSyncAll_Click" EnableViewState="false" Text="Synchronize all" ButtonStyle="Primary" />
         <cms:LocalizedButton runat="server" ID="btnDangerZone" OnClick="btnDangerZone_Click" Text="Show advanced actions" ButtonStyle="Default" />
-        <asp:PlaceHolder runat="server" ID="plcDangerZone" Visible="false">
+        <asp:Panel runat="server" ID="pnlDangerZone" Visible="false">
+            <br />
             <cms:LocalizedButton ID="btnSyncMediaLibraries" runat="server" OnClick="btnSyncMediaLibraries_Click" EnableViewState="false" Text="Synchronize media libraries" ButtonStyle="Default" />
+            <br /><br />
             <cms:LocalizedButton ID="btnSyncRelationships" runat="server" OnClick="btnSyncRelationships_Click" EnableViewState="false" Text="Synchronize relationships" ButtonStyle="Default" />
+            <br /><br />
             <cms:LocalizedButton ID="btnSyncCategories" runat="server" OnClick="btnSyncCategories_Click" EnableViewState="false" Text="Synchronize categories" ButtonStyle="Default" />
+            <br /><br />
             <cms:LocalizedButton ID="btnSyncContentTypes" runat="server" OnClick="btnSyncContentTypes_Click" EnableViewState="false" Text="Synchronize content types" ButtonStyle="Default" />
+            <br /><br />
             <cms:LocalizedButton ID="btnSyncAttachments" runat="server" OnClick="btnSyncAttachments_Click" EnableViewState="false" Text="Synchronize attachments" ButtonStyle="Default" />
+            <br /><br />
             <cms:LocalizedButton ID="btnSyncLanguages" runat="server" OnClick="btnSyncLanguages_Click" EnableViewState="false" Text="Synchronize cultures" ButtonStyle="Default" />
+            <br /><br />
             <cms:LocalizedButton ID="btnSyncPages" runat="server" OnClick="btnSyncPages_Click" EnableViewState="false" Text="Synchronize pages" ButtonStyle="Default" />
+            <br /><br />
             <cms:LocalizedButton ID="btnDeleteAll" runat="server" OnClick="btnDeleteAll_Click" EnableViewState="false" Text="Delete all data in Kentico Kontent" ButtonStyle="Default" OnClientClick="return confirm('This will delete all data in the target Kentico Cloud project, not only the data synchronized from this site. Are you sure you want to continue?')" />
-        </asp:PlaceHolder>
+        </asp:Panel>
     </asp:PlaceHolder>
 </asp:Content>

--- a/CMS/CMSModules/Kentico.KontentPublishing/Pages/Sync.aspx.cs
+++ b/CMS/CMSModules/Kentico.KontentPublishing/Pages/Sync.aspx.cs
@@ -37,6 +37,13 @@ public partial class CMSModules_Kentico_KontentPublishing_Pages_Sync : GlobalAdm
             Text = "Kentico Kontent Publishing",
         });
 
+        if (!GetModule().isConfigurationValid())
+        {
+            plcSync.Visible = false;
+            ShowWarning("Kentico Kontent Publishing configuration is invalid, check the configuration.");
+            return;
+        }
+
         ctlAsyncLog.TitleText = "Synchronization in progress ...";
 
         ctlAsyncLog.OnFinished += OnFinished;
@@ -113,6 +120,7 @@ public partial class CMSModules_Kentico_KontentPublishing_Pages_Sync : GlobalAdm
                 }
                 catch (Exception ex)
                 {
+                    SyncLog.LogException("KenticoKontentPublishing", "UNHANDLEDERROR", ex);
                     SyncLog.Log(ex.Message);
                     ctlAsyncLog.ProcessData.Error = ex.Message;
                 }
@@ -218,7 +226,7 @@ public partial class CMSModules_Kentico_KontentPublishing_Pages_Sync : GlobalAdm
 
     protected void btnDangerZone_Click(object sender, EventArgs e)
     {
-        plcDangerZone.Visible = true;
+        pnlDangerZone.Visible = true;
         btnDangerZone.Visible = false;
         ShowWarning("DANGER ZONE: The extra actions are meant for debug and cleanup purposes, use with caution.");
     }

--- a/CMS/CMSModules/Kentico.KontentPublishing/Pages/Sync.aspx.cs
+++ b/CMS/CMSModules/Kentico.KontentPublishing/Pages/Sync.aspx.cs
@@ -30,11 +30,11 @@ public partial class CMSModules_Kentico_KontentPublishing_Pages_Sync : GlobalAdm
 
     protected void Page_Load(object sender, EventArgs e)
     {
-        PageTitle.TitleText = "Kentico Cloud Publishing";
+        PageTitle.TitleText = "Kentico Kontent Publishing";
 
         PageBreadcrumbs.Items.Add(new BreadcrumbItem
         {
-            Text = "Kentico Cloud Publishing",
+            Text = "Kentico Kontent Publishing",
         });
 
         ctlAsyncLog.TitleText = "Synchronization in progress ...";

--- a/CMS/CMSModules/Kentico.KontentPublishing/Pages/Sync.aspx.cs
+++ b/CMS/CMSModules/Kentico.KontentPublishing/Pages/Sync.aspx.cs
@@ -169,6 +169,26 @@ public partial class CMSModules_Kentico_KontentPublishing_Pages_Sync : GlobalAdm
         await GetModule()?.SyncLanguages(cancellation);
     }
 
+    private async Task DeleteItems(CancellationToken cancellation)
+    {
+        await GetModule()?.DeleteItems(cancellation);
+    }
+
+    private async Task DeleteContentTypes(CancellationToken cancellation)
+    {
+        await GetModule()?.DeleteContentTypes(cancellation);
+    }
+
+    private async Task DeleteSnippets(CancellationToken cancellation)
+    {
+        await GetModule()?.DeleteContentTypeSnippets(cancellation);
+    }
+
+    private async Task DeleteAssets(CancellationToken cancellation)
+    {
+        await GetModule()?.DeleteAssets(cancellation);
+    }
+
     private async Task DeleteAll(CancellationToken cancellation)
     {
         await GetModule()?.DeleteAll(cancellation);
@@ -217,6 +237,26 @@ public partial class CMSModules_Kentico_KontentPublishing_Pages_Sync : GlobalAdm
     protected void btnSyncCategories_Click(object sender, EventArgs e)
     {
         RunSync(SyncCategories);
+    }
+    
+    protected void btnDeleteItems_Click(object sender, EventArgs e)
+    {
+        RunSync(DeleteItems);
+    }
+
+    protected void btnDeleteContentTypes_Click(object sender, EventArgs e)
+    {
+        RunSync(DeleteContentTypes);
+    }
+
+    protected void btnDeleteSnippets_Click(object sender, EventArgs e)
+    {
+        RunSync(DeleteSnippets);
+    }
+
+    protected void btnDeleteAssets_Click(object sender, EventArgs e)
+    {
+        RunSync(DeleteAssets);
     }
 
     protected void btnDeleteAll_Click(object sender, EventArgs e)

--- a/CMS/CMSModules/Kentico.KontentPublishing/Pages/Sync.aspx.cs
+++ b/CMS/CMSModules/Kentico.KontentPublishing/Pages/Sync.aspx.cs
@@ -37,7 +37,7 @@ public partial class CMSModules_Kentico_KontentPublishing_Pages_Sync : GlobalAdm
             Text = "Kentico Kontent Publishing",
         });
 
-        if (!GetModule().isConfigurationValid())
+        if (!GetModule().IsConfigurationValid())
         {
             plcSync.Visible = false;
             ShowWarning("Kentico Kontent Publishing configuration is invalid, check the configuration.");
@@ -121,7 +121,6 @@ public partial class CMSModules_Kentico_KontentPublishing_Pages_Sync : GlobalAdm
                 catch (Exception ex)
                 {
                     SyncLog.LogException("KenticoKontentPublishing", "UNHANDLEDERROR", ex);
-                    SyncLog.Log(ex.Message);
                     ctlAsyncLog.ProcessData.Error = ex.Message;
                 }
             }).Wait(),
@@ -136,12 +135,12 @@ public partial class CMSModules_Kentico_KontentPublishing_Pages_Sync : GlobalAdm
 
     private async Task SyncRelationships(CancellationToken cancellation)
     {
-        await GetModule()?.SyncRelationships(cancellation);
+        await GetModule()?.SyncRelationships();
     }
 
     private async Task SyncCategories(CancellationToken cancellation)
     {
-        await GetModule()?.SyncCategories(cancellation);
+        await GetModule()?.SyncCategories();
     }
 
     private async Task SyncMediaLibraries(CancellationToken cancellation)
@@ -166,7 +165,7 @@ public partial class CMSModules_Kentico_KontentPublishing_Pages_Sync : GlobalAdm
 
     private async Task SyncLanguages(CancellationToken cancellation)
     {
-        await GetModule()?.SyncLanguages(cancellation);
+        await GetModule()?.SyncLanguages();
     }
 
     private async Task DeleteItems(CancellationToken cancellation)

--- a/CMS/CMSModules/Kentico.KontentPublishing/Pages/Sync.aspx.designer.cs
+++ b/CMS/CMSModules/Kentico.KontentPublishing/Pages/Sync.aspx.designer.cs
@@ -11,7 +11,7 @@
 
 public partial class CMSModules_Kentico_KontentPublishing_Pages_Sync
 {
-    
+
     /// <summary>
     /// pnlLog control.
     /// </summary>
@@ -20,7 +20,7 @@ public partial class CMSModules_Kentico_KontentPublishing_Pages_Sync
     /// To modify move field declaration from designer file to code-behind file.
     /// </remarks>
     protected global::System.Web.UI.WebControls.Panel pnlLog;
-    
+
     /// <summary>
     /// ctlAsyncLog control.
     /// </summary>
@@ -29,16 +29,16 @@ public partial class CMSModules_Kentico_KontentPublishing_Pages_Sync
     /// To modify move field declaration from designer file to code-behind file.
     /// </remarks>
     protected global::CMSAdminControls_AsyncLogDialog ctlAsyncLog;
-    
+
     /// <summary>
-    /// plcTextBox control.
+    /// plcSync control.
     /// </summary>
     /// <remarks>
     /// Auto-generated field.
     /// To modify move field declaration from designer file to code-behind file.
     /// </remarks>
-    protected global::System.Web.UI.WebControls.PlaceHolder plcTextBox;
-    
+    protected global::System.Web.UI.WebControls.PlaceHolder plcSync;
+
     /// <summary>
     /// btnSyncAll control.
     /// </summary>
@@ -47,7 +47,7 @@ public partial class CMSModules_Kentico_KontentPublishing_Pages_Sync
     /// To modify move field declaration from designer file to code-behind file.
     /// </remarks>
     protected global::CMS.Base.Web.UI.LocalizedButton btnSyncAll;
-    
+
     /// <summary>
     /// btnDangerZone control.
     /// </summary>
@@ -56,16 +56,16 @@ public partial class CMSModules_Kentico_KontentPublishing_Pages_Sync
     /// To modify move field declaration from designer file to code-behind file.
     /// </remarks>
     protected global::CMS.Base.Web.UI.LocalizedButton btnDangerZone;
-    
+
     /// <summary>
-    /// plcDangerZone control.
+    /// pnlDangerZone control.
     /// </summary>
     /// <remarks>
     /// Auto-generated field.
     /// To modify move field declaration from designer file to code-behind file.
     /// </remarks>
-    protected global::System.Web.UI.WebControls.PlaceHolder plcDangerZone;
-    
+    protected global::System.Web.UI.WebControls.Panel pnlDangerZone;
+
     /// <summary>
     /// btnSyncMediaLibraries control.
     /// </summary>
@@ -74,7 +74,7 @@ public partial class CMSModules_Kentico_KontentPublishing_Pages_Sync
     /// To modify move field declaration from designer file to code-behind file.
     /// </remarks>
     protected global::CMS.Base.Web.UI.LocalizedButton btnSyncMediaLibraries;
-    
+
     /// <summary>
     /// btnSyncRelationships control.
     /// </summary>
@@ -83,7 +83,7 @@ public partial class CMSModules_Kentico_KontentPublishing_Pages_Sync
     /// To modify move field declaration from designer file to code-behind file.
     /// </remarks>
     protected global::CMS.Base.Web.UI.LocalizedButton btnSyncRelationships;
-    
+
     /// <summary>
     /// btnSyncCategories control.
     /// </summary>
@@ -92,7 +92,7 @@ public partial class CMSModules_Kentico_KontentPublishing_Pages_Sync
     /// To modify move field declaration from designer file to code-behind file.
     /// </remarks>
     protected global::CMS.Base.Web.UI.LocalizedButton btnSyncCategories;
-    
+
     /// <summary>
     /// btnSyncContentTypes control.
     /// </summary>
@@ -101,7 +101,7 @@ public partial class CMSModules_Kentico_KontentPublishing_Pages_Sync
     /// To modify move field declaration from designer file to code-behind file.
     /// </remarks>
     protected global::CMS.Base.Web.UI.LocalizedButton btnSyncContentTypes;
-    
+
     /// <summary>
     /// btnSyncAttachments control.
     /// </summary>
@@ -110,7 +110,7 @@ public partial class CMSModules_Kentico_KontentPublishing_Pages_Sync
     /// To modify move field declaration from designer file to code-behind file.
     /// </remarks>
     protected global::CMS.Base.Web.UI.LocalizedButton btnSyncAttachments;
-    
+
     /// <summary>
     /// btnSyncLanguages control.
     /// </summary>
@@ -119,7 +119,7 @@ public partial class CMSModules_Kentico_KontentPublishing_Pages_Sync
     /// To modify move field declaration from designer file to code-behind file.
     /// </remarks>
     protected global::CMS.Base.Web.UI.LocalizedButton btnSyncLanguages;
-    
+
     /// <summary>
     /// btnSyncPages control.
     /// </summary>
@@ -128,7 +128,7 @@ public partial class CMSModules_Kentico_KontentPublishing_Pages_Sync
     /// To modify move field declaration from designer file to code-behind file.
     /// </remarks>
     protected global::CMS.Base.Web.UI.LocalizedButton btnSyncPages;
-    
+
     /// <summary>
     /// btnDeleteAll control.
     /// </summary>

--- a/CMS/CMSModules/Kentico.KontentPublishing/Pages/Sync.aspx.designer.cs
+++ b/CMS/CMSModules/Kentico.KontentPublishing/Pages/Sync.aspx.designer.cs
@@ -67,6 +67,15 @@ public partial class CMSModules_Kentico_KontentPublishing_Pages_Sync
     protected global::System.Web.UI.WebControls.Panel pnlDangerZone;
 
     /// <summary>
+    /// btnDeleteAll control.
+    /// </summary>
+    /// <remarks>
+    /// Auto-generated field.
+    /// To modify move field declaration from designer file to code-behind file.
+    /// </remarks>
+    protected global::CMS.Base.Web.UI.LocalizedButton btnDeleteAll;
+
+    /// <summary>
     /// btnSyncMediaLibraries control.
     /// </summary>
     /// <remarks>
@@ -130,11 +139,38 @@ public partial class CMSModules_Kentico_KontentPublishing_Pages_Sync
     protected global::CMS.Base.Web.UI.LocalizedButton btnSyncPages;
 
     /// <summary>
-    /// btnDeleteAll control.
+    /// btnDeleteItems control.
     /// </summary>
     /// <remarks>
     /// Auto-generated field.
     /// To modify move field declaration from designer file to code-behind file.
     /// </remarks>
-    protected global::CMS.Base.Web.UI.LocalizedButton btnDeleteAll;
+    protected global::CMS.Base.Web.UI.LocalizedButton btnDeleteItems;
+
+    /// <summary>
+    /// btnDeleteContentTypes control.
+    /// </summary>
+    /// <remarks>
+    /// Auto-generated field.
+    /// To modify move field declaration from designer file to code-behind file.
+    /// </remarks>
+    protected global::CMS.Base.Web.UI.LocalizedButton btnDeleteContentTypes;
+
+    /// <summary>
+    /// btnDeleteSnippets control.
+    /// </summary>
+    /// <remarks>
+    /// Auto-generated field.
+    /// To modify move field declaration from designer file to code-behind file.
+    /// </remarks>
+    protected global::CMS.Base.Web.UI.LocalizedButton btnDeleteSnippets;
+
+    /// <summary>
+    /// btnDeleteAssets control.
+    /// </summary>
+    /// <remarks>
+    /// Auto-generated field.
+    /// To modify move field declaration from designer file to code-behind file.
+    /// </remarks>
+    protected global::CMS.Base.Web.UI.LocalizedButton btnDeleteAssets;
 }

--- a/Kentico.KontentPublishing/Helpers/KontentSyncWorker.cs
+++ b/Kentico.KontentPublishing/Helpers/KontentSyncWorker.cs
@@ -2,7 +2,7 @@
 
 namespace Kentico.EMS.Kontent.Publishing
 {
-    internal class CloudSyncWorker : SimpleQueueWorker<CloudSyncWorker>
+    internal class KontentSyncWorker : SimpleQueueWorker<KontentSyncWorker>
     {
     }
 }

--- a/Kentico.KontentPublishing/Helpers/SyncLog.cs
+++ b/Kentico.KontentPublishing/Helpers/SyncLog.cs
@@ -3,7 +3,7 @@ using System;
 
 namespace Kentico.EMS.Kontent.Publishing
 {
-    public class SyncLog
+    public static class SyncLog
     {
         public static Exception lastLoggedException;
         public static LogContext CurrentLog;

--- a/Kentico.KontentPublishing/Helpers/SyncLog.cs
+++ b/Kentico.KontentPublishing/Helpers/SyncLog.cs
@@ -5,6 +5,7 @@ namespace Kentico.EMS.Kontent.Publishing
 {
     public class SyncLog
     {
+        public static Exception lastLoggedException;
         public static LogContext CurrentLog;
         
         public static void Log(string text, bool newLine = true)
@@ -23,7 +24,13 @@ namespace Kentico.EMS.Kontent.Publishing
 
         public static void LogException(string source, string eventCode, Exception ex, int siteId = 0, string additionalMessage = null)
         {
+            // Do not log the same exception twice
+            if (ex == lastLoggedException)
+            {
+                return;
+            }
             EventLogProvider.LogException(source, eventCode, ex, siteId, additionalMessage);
+            lastLoggedException = ex;
         }
     }
 }

--- a/Kentico.KontentPublishing/Kentico.KontentPublishing.csproj
+++ b/Kentico.KontentPublishing/Kentico.KontentPublishing.csproj
@@ -574,7 +574,7 @@
     <Reference Include="WindowsBase" />
   </ItemGroup>
   <ItemGroup>
-    <Compile Include="Helpers\CloudSyncWorker.cs" />
+    <Compile Include="Helpers\KontentSyncWorker.cs" />
     <Compile Include="Helpers\SyncLog.cs" />
     <Compile Include="Models\ContentTypes\ElementData.cs" />
     <Compile Include="Models\ContentTypes\SnippetData.cs" />
@@ -586,6 +586,7 @@
     <Compile Include="Models\Assets\AssetsResponse.cs" />
     <Compile Include="Models\Languages\LanguageData.cs" />
     <Compile Include="Models\Languages\LanguagesResponse.cs" />
+    <Compile Include="Models\Taxonomies\TaxonomyResponse.cs" />
     <Compile Include="Models\Taxonomies\TaxonomyData.cs" />
     <Compile Include="Sync\AssetSync.cs" />
     <Compile Include="Models\ContentTypes\ContentTypesResponse.cs" />

--- a/Kentico.KontentPublishing/Kentico.KontentPublishing.csproj
+++ b/Kentico.KontentPublishing/Kentico.KontentPublishing.csproj
@@ -595,6 +595,7 @@
     <Compile Include="Models\Items\ItemsResponse.cs" />
     <Compile Include="Models\ContentTypes\MultipleChoiceElementOption.cs" />
     <Compile Include="Models\Taxonomies\CategoryTerm.cs" />
+    <Compile Include="Sync\LinkTranslator.cs" />
     <Compile Include="Sync\NodeWithoutPublishFrom.cs" />
     <Compile Include="Sync\PageSync.cs" />
     <Compile Include="Sync\ContentTypeSync.cs" />

--- a/Kentico.KontentPublishing/Kentico.KontentPublishing.csproj
+++ b/Kentico.KontentPublishing/Kentico.KontentPublishing.csproj
@@ -576,6 +576,7 @@
   <ItemGroup>
     <Compile Include="Helpers\KontentSyncWorker.cs" />
     <Compile Include="Helpers\SyncLog.cs" />
+    <Compile Include="Models\ContentTypes\ContentGroupData.cs" />
     <Compile Include="Models\ContentTypes\ElementData.cs" />
     <Compile Include="Models\ContentTypes\SnippetData.cs" />
     <Compile Include="Models\ContentTypes\SnippetsResponse.cs" />

--- a/Kentico.KontentPublishing/Kentico.KontentPublishing.csproj
+++ b/Kentico.KontentPublishing/Kentico.KontentPublishing.csproj
@@ -601,7 +601,6 @@
     <Compile Include="KontentPublishingModule.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Helpers\RegExExtensions.cs" />
-    <Compile Include="Sync\Purge.cs" />
     <Compile Include="Models\General\ExternalIdReference.cs" />
     <Compile Include="Sync\StringExtensions.cs" />
     <Compile Include="Sync\SyncBase.cs" />

--- a/Kentico.KontentPublishing/Kentico.KontentPublishing.csproj
+++ b/Kentico.KontentPublishing/Kentico.KontentPublishing.csproj
@@ -603,6 +603,7 @@
     <Compile Include="Helpers\RegExExtensions.cs" />
     <Compile Include="Sync\Purge.cs" />
     <Compile Include="Models\General\ExternalIdReference.cs" />
+    <Compile Include="Sync\StringExtensions.cs" />
     <Compile Include="Sync\SyncBase.cs" />
     <Compile Include="Sync\SyncSettings.cs" />
     <Compile Include="Models\General\IdReference.cs" />

--- a/Kentico.KontentPublishing/KontentPublishingModule.cs
+++ b/Kentico.KontentPublishing/KontentPublishingModule.cs
@@ -61,7 +61,7 @@ namespace Kentico.EMS.Kontent.Publishing
 
                 RelationshipNameInfo.TYPEINFO.Events.Insert.After += RelationshipNameCreated;
                 RelationshipNameInfo.TYPEINFO.Events.Update.Before += RelationshipNameUpdating;
-                RelationshipNameInfo.TYPEINFO.Events.Delete.After += RelationshipsNameDeleted;
+                RelationshipNameInfo.TYPEINFO.Events.Delete.Before += RelationshipsNameDeleting;
 
                 RelationshipNameSiteInfo.TYPEINFO.Events.Insert.After += RelationshipNameSiteChanged;
                 RelationshipNameSiteInfo.TYPEINFO.Events.Delete.After += RelationshipNameSiteChanged;
@@ -199,12 +199,14 @@ namespace Kentico.EMS.Kontent.Publishing
             }
         }
 
-        private void RelationshipsNameDeleted(object sender, ObjectEventArgs e)
+        private void RelationshipsNameDeleting(object sender, ObjectEventArgs e)
         {
             var relationshipName = e.Object as RelationshipNameInfo;
             if ((relationshipName != null) && _contentTypeSync.IsAtSynchronizedSite(relationshipName))
             {
-                RunSynchronization(async () => await _contentTypeSync.SyncRelationships(null));
+                e.CallWhenFinished(
+                    () => RunSynchronization(async () => await _contentTypeSync.SyncRelationships(null))
+                );
             }
         }
 

--- a/Kentico.KontentPublishing/KontentPublishingModule.cs
+++ b/Kentico.KontentPublishing/KontentPublishingModule.cs
@@ -102,7 +102,7 @@ namespace Kentico.EMS.Kontent.Publishing
         
         private void RunSynchronization(Func<Task> action)
         {
-            CloudSyncWorker.Current.Enqueue(
+            KontentSyncWorker.Current.Enqueue(
                 () => Task.Run(async () => await action()).Wait()
             );
         }

--- a/Kentico.KontentPublishing/KontentPublishingModule.cs
+++ b/Kentico.KontentPublishing/KontentPublishingModule.cs
@@ -537,6 +537,7 @@ namespace Kentico.EMS.Kontent.Publishing
                             .OnSite(node.NodeSiteName)
                             .Path(node.NodeAliasPath, PathTypeEnum.Section)
                             .AllCultures()
+                            .WithCoupledColumns()
                             .TypedResult
                             .ToList();
 

--- a/Kentico.KontentPublishing/KontentPublishingModule.cs
+++ b/Kentico.KontentPublishing/KontentPublishingModule.cs
@@ -38,8 +38,8 @@ namespace Kentico.EMS.Kontent.Publishing
             {
                 _assetSync = new AssetSync(_settings);
                 _languageSync = new LanguageSync(_settings);
-                _pageSync = new PageSync(_settings, _assetSync);
                 _contentTypeSync = new ContentTypeSync(_settings);
+                _pageSync = new PageSync(_settings, _assetSync, _contentTypeSync);
                 _taxonomySync = new TaxonomySync(_settings);
             }
         }

--- a/Kentico.KontentPublishing/Models/ContentTypes/ContentGroupData.cs
+++ b/Kentico.KontentPublishing/Models/ContentTypes/ContentGroupData.cs
@@ -1,0 +1,11 @@
+﻿using System;
+using Newtonsoft.Json;
+
+namespace Kentico.EMS.Kontent.Publishing
+{
+    internal class ContentGroupData
+    {
+        [JsonProperty("id")]
+        public Guid Id { get; set; }
+    }
+}

--- a/Kentico.KontentPublishing/Models/ContentTypes/ContentTypeData.cs
+++ b/Kentico.KontentPublishing/Models/ContentTypes/ContentTypeData.cs
@@ -11,5 +11,8 @@ namespace Kentico.EMS.Kontent.Publishing
 
         [JsonProperty("elements")]
         public IEnumerable<ElementData> Elements { get; set; }
+
+        [JsonProperty("content_groups")]
+        public IEnumerable<ContentGroupData> ContentGroups { get; set; }
     }
 }

--- a/Kentico.KontentPublishing/Models/ContentTypes/MultipleChoiceElementOption.cs
+++ b/Kentico.KontentPublishing/Models/ContentTypes/MultipleChoiceElementOption.cs
@@ -9,5 +9,8 @@ namespace Kentico.EMS.Kontent.Publishing
 
         [JsonProperty("codename")]
         public string Codename { get; set; }
+
+        [JsonProperty("external_id")]
+        public string ExternalId { get; set; }
     }
 }

--- a/Kentico.KontentPublishing/Models/ContentTypes/MultipleChoiceElementOption.cs
+++ b/Kentico.KontentPublishing/Models/ContentTypes/MultipleChoiceElementOption.cs
@@ -1,7 +1,13 @@
-﻿namespace Kentico.EMS.Kontent.Publishing
+﻿using Newtonsoft.Json;
+
+namespace Kentico.EMS.Kontent.Publishing
 {
     internal class MultipleChoiceElementOption
     {
-        public string name { get; set; }
+        [JsonProperty("name")]
+        public string Name { get; set; }
+
+        [JsonProperty("codename")]
+        public string Codename { get; set; }
     }
 }

--- a/Kentico.KontentPublishing/Models/General/ExternalIdReference.cs
+++ b/Kentico.KontentPublishing/Models/General/ExternalIdReference.cs
@@ -1,7 +1,10 @@
-﻿namespace Kentico.EMS.Kontent.Publishing
+﻿using Newtonsoft.Json;
+
+namespace Kentico.EMS.Kontent.Publishing
 {
     internal class ExternalIdReference
     {
-        public string external_id { get; set; }
+        [JsonProperty("external_id")]
+        public string ExternalId { get; set; }
     }
 }

--- a/Kentico.KontentPublishing/Models/Languages/LanguageData.cs
+++ b/Kentico.KontentPublishing/Models/Languages/LanguageData.cs
@@ -1,5 +1,4 @@
-﻿
-using System;
+﻿using System;
 
 using Newtonsoft.Json;
 
@@ -10,7 +9,16 @@ namespace Kentico.EMS.Kontent.Publishing
         [JsonProperty("id")]
         public Guid Id { get; set; }
 
+        [JsonProperty("external_id")]
+        public string ExternalId { get; set; }
+
         [JsonProperty("codename")]
         public string Codename { get; set; }
+
+        [JsonProperty("name")]
+        public string Name { get; set; }
+
+        [JsonProperty("is_active")]
+        public bool IsActive { get; set; }
     }
 }

--- a/Kentico.KontentPublishing/Models/Taxonomies/CategoryTerm.cs
+++ b/Kentico.KontentPublishing/Models/Taxonomies/CategoryTerm.cs
@@ -1,15 +1,20 @@
-﻿using System.Collections.Generic;
+﻿using Newtonsoft.Json;
+using System.Collections.Generic;
 
 namespace Kentico.EMS.Kontent.Publishing
 {
     internal class CategoryTerm
     {
-        public string name { get; set; }
+        [JsonProperty("name")]
+        public string Name { get; set; }
 
-        public string codename { get; set; }
+        [JsonProperty("codename")]
+        public string Codename { get; set; }
 
-        public string external_id { get; set; }
+        [JsonProperty("external_id")]
+        public string ExternalId { get; set; }
 
-        public IEnumerable<CategoryTerm> terms { get; set; }
+        [JsonProperty("terms")]
+        public IEnumerable<CategoryTerm> Terms { get; set; }
     }
 }

--- a/Kentico.KontentPublishing/Models/Taxonomies/CategoryTerm.cs
+++ b/Kentico.KontentPublishing/Models/Taxonomies/CategoryTerm.cs
@@ -6,6 +6,8 @@ namespace Kentico.EMS.Kontent.Publishing
     {
         public string name { get; set; }
 
+        public string codename { get; set; }
+
         public string external_id { get; set; }
 
         public IEnumerable<CategoryTerm> terms { get; set; }

--- a/Kentico.KontentPublishing/Models/Taxonomies/TaxonomyResponse.cs
+++ b/Kentico.KontentPublishing/Models/Taxonomies/TaxonomyResponse.cs
@@ -1,0 +1,15 @@
+﻿
+using Newtonsoft.Json;
+using System.Collections.Generic;
+
+namespace Kentico.EMS.Kontent.Publishing
+{
+    internal class TaxonomyResponse
+    {
+        [JsonProperty("taxonomies")]
+        public IEnumerable<TaxonomyData> Taxonomies { get; set; }
+
+        [JsonProperty("pagination")]
+        public PaginationData Pagination { get; set; }
+    }
+}

--- a/Kentico.KontentPublishing/Sync/AssetSync.cs
+++ b/Kentico.KontentPublishing/Sync/AssetSync.cs
@@ -281,19 +281,25 @@ namespace Kentico.EMS.Kontent.Publishing
             }
         }
 
-        public async Task DeleteAllMediaFiles(MediaLibraryInfo mediaLibrary)
+        public async Task DeleteMediaFiles(CancellationToken? cancellation, ICollection<MediaFileInfo> mediaFiles, string info)
         {
             try
             {
-                SyncLog.LogEvent(EventType.INFORMATION, "KenticoKontentPublishing", "DELETEMEDIAFILES", mediaLibrary.LibraryDisplayName);
+                SyncLog.LogEvent(EventType.INFORMATION, "KenticoKontentPublishing", "DELETEMEDIAFILES", info);
 
-                var mediaFiles = MediaFileInfoProvider.GetMediaFiles()
-                    .WhereEquals("FileLibraryID", mediaLibrary.LibraryID)
-                    .BinaryData(false)
-                    .TypedResult;
+                var index = 0;
 
                 foreach (var mediaFile in mediaFiles)
                 {
+                    if (cancellation?.IsCancellationRequested == true)
+                    {
+                        return;
+                    }
+
+                    index++;
+
+                    SyncLog.Log($"Deleting media file {mediaFile.FileName} ({index}/{mediaFiles.Count})");
+
                     await DeleteMediaFile(mediaFile);
                 }
             }
@@ -386,14 +392,11 @@ namespace Kentico.EMS.Kontent.Publishing
             }
         }
 
-        public async Task DeleteAllAttachments(CancellationToken? cancellation, TreeNode node)
+        public async Task DeleteAttachments(CancellationToken? cancellation, ICollection<AttachmentInfo> attachments, string info)
         {
             try
             {
-                SyncLog.LogEvent(EventType.INFORMATION, "KenticoKontentPublishing", "DELETEATTACHMENTS", node.NodeAliasPath);
-
-                var attachments = AttachmentInfoProvider.GetAttachments(node.DocumentID, false)
-                    .ExceptVariants();
+                SyncLog.LogEvent(EventType.INFORMATION, "KenticoKontentPublishing", "DELETEATTACHMENTS", info);
 
                 var index = 0;
 

--- a/Kentico.KontentPublishing/Sync/AssetSync.cs
+++ b/Kentico.KontentPublishing/Sync/AssetSync.cs
@@ -338,7 +338,7 @@ namespace Kentico.EMS.Kontent.Publishing
                 var fileName = GetShortenedFileName(fullFileName);
                 var title = string.IsNullOrEmpty(mediaFile.FileTitle) ? fileName : mediaFile.FileTitle;
 
-                // TODO - Consider detection by something more sophisticated than file size, but be careful, last modified may be off due to metadata changes
+                // TODO - Consider detection by something more sophisticated than file size + name, but be careful, last modified may be off due to metadata changes
                 if ((existing == null) || (mediaFile.FileSize != existing.Size) || (fileName != existing.FileName))
                 {
                     // Upload new 
@@ -515,8 +515,7 @@ namespace Kentico.EMS.Kontent.Publishing
 
                 var existing = await GetAsset(externalId);
 
-                // TODO - Consider detection by something more sophisticated than file size + name
-                // but be careful, last modified may be off due to metadata changes
+                // TODO - Consider detection by something more sophisticated than file size + name, but be careful, last modified may be off due to metadata changes
                 if ((existing == null) || (attachment.AttachmentSize != existing.Size) || (fileName != existing.FileName))
                 {
                     // Upload new 

--- a/Kentico.KontentPublishing/Sync/AssetSync.cs
+++ b/Kentico.KontentPublishing/Sync/AssetSync.cs
@@ -177,7 +177,8 @@ namespace Kentico.EMS.Kontent.Publishing
                     id = fileReferenceId,
                     type = "internal"
                 },
-                title,
+                title = title.LimitedTo(ASSET_TITLE_MAXLENGTH),
+                folder = new { id = Guid.Empty },
                 descriptions = new []
                 {
                     new
@@ -319,6 +320,7 @@ namespace Kentico.EMS.Kontent.Publishing
                 var externalId = GetMediaFileExternalId(mediaFile.FileGUID);
 
                 var existing = await GetAsset(externalId);
+                var title = string.IsNullOrEmpty(mediaFile.FileTitle) ? fileName : mediaFile.FileTitle;
 
                 // TODO - Consider detection by something more sophisticated than file size, but be careful, last modified may be off due to metadata changes
                 if ((existing == null) || (mediaFile.FileSize != existing.Size))
@@ -331,12 +333,12 @@ namespace Kentico.EMS.Kontent.Publishing
                     var data = File.ReadAllBytes(filePath);
                     var fileReference = await UploadBinaryFile(data, mediaFile.FileMimeType, fileName);
 
-                    await UpsertAsset(externalId, fileName, mediaFile.FileDescription, fileReference.Id);
+                    await UpsertAsset(externalId, title, mediaFile.FileDescription, fileReference.Id);
                 }
                 else
                 {
                     // Update metadata of existing
-                    await UpsertAsset(externalId, fileName, mediaFile.FileDescription, existing.FileReference.Id);
+                    await UpsertAsset(externalId, title, mediaFile.FileDescription, existing.FileReference.Id);
                 }
             }
             catch (Exception ex)
@@ -488,6 +490,7 @@ namespace Kentico.EMS.Kontent.Publishing
                 SyncLog.LogEvent(EventType.INFORMATION, "KenticoKontentPublishing", "SYNCATTACHMENT", attachment.AttachmentName);
 
                 var externalId = GetAttachmentExternalId(attachment.AttachmentGUID);
+                var title = string.IsNullOrEmpty(attachment.AttachmentTitle) ? attachment.AttachmentName : attachment.AttachmentTitle;
 
                 var existing = await GetAsset(externalId);
 
@@ -499,12 +502,12 @@ namespace Kentico.EMS.Kontent.Publishing
                     var data = AttachmentBinaryHelper.GetAttachmentBinary((DocumentAttachment)attachment);
                     var fileReference = await UploadBinaryFile(data, attachment.AttachmentMimeType, attachment.AttachmentName);
 
-                    await UpsertAsset(externalId, attachment.AttachmentName, attachment.AttachmentDescription, fileReference.Id);
+                    await UpsertAsset(externalId, title, attachment.AttachmentDescription, fileReference.Id);
                 }
                 else
                 {
                     // Update metadata of existing
-                    await UpsertAsset(externalId, attachment.AttachmentName, attachment.AttachmentDescription, existing.FileReference.Id);
+                    await UpsertAsset(externalId, title, attachment.AttachmentDescription, existing.FileReference.Id);
                 }
             }
             catch (Exception ex)

--- a/Kentico.KontentPublishing/Sync/AssetSync.cs
+++ b/Kentico.KontentPublishing/Sync/AssetSync.cs
@@ -57,10 +57,9 @@ namespace Kentico.EMS.Kontent.Publishing
 
         private async Task<List<Guid>> GetAllAssetIds(string continuationToken = null)
         {
-            var query = (continuationToken != null) ? "?continuationToken=" + HttpUtility.UrlEncode(continuationToken) : "";
-            var endpoint = $"/assets{query}";
+            var endpoint = $"/assets";
 
-            var response = await ExecuteWithResponse<AssetsResponse>(endpoint, HttpMethod.Get);
+            var response = await ExecuteWithResponse<AssetsResponse>(endpoint, HttpMethod.Get, continuationToken);
             if (response == null)
             {
                 return new List<Guid>();

--- a/Kentico.KontentPublishing/Sync/ContentTypeSync.cs
+++ b/Kentico.KontentPublishing/Sync/ContentTypeSync.cs
@@ -476,16 +476,20 @@ namespace Kentico.EMS.Kontent.Publishing
                 var field = item as FormFieldInfo;
                 if (field != null)
                 {
+                    var isRequired = !field.AllowEmpty &&
+                        // Exception - CM-13044 File field cannot be required because when a new document under workflow is created, it creates a document which appears published for a moment
+                        // but the attachment is not present at that time so publishing of such document would fail immediately
+                        (field.DataType != FieldDataType.File) &&
+                        // Exception - Allow empty value for root document name
+                        ((field.Name.ToLowerInvariant() != "documentname") || (contentType.ClassName.ToLowerInvariant() != "cms.root"));
+
                     var element = new
                     {
                         external_id = GetFieldExternalId(contentType.ClassGUID, field.Guid),
                         name = GetElementName(field).LimitedTo(ELEMENT_MAXLENGTH),
                         codename = field.Name.ToLower().LimitedTo(ELEMENT_MAXLENGTH),
                         guidelines = GetElementGuidelines(field),
-                        is_required =
-                            !field.AllowEmpty &&
-                            // Exception - Allow empty value for root document name
-                            ((field.Name.ToLowerInvariant() != "documentname") || (contentType.ClassName.ToLowerInvariant() != "cms.root")),
+                        is_required = isRequired,
                         type = GetElementType(field.DataType),
                         options = (field.DataType == FieldDataType.Binary)
                             ? new[] {

--- a/Kentico.KontentPublishing/Sync/ContentTypeSync.cs
+++ b/Kentico.KontentPublishing/Sync/ContentTypeSync.cs
@@ -87,10 +87,10 @@ namespace Kentico.EMS.Kontent.Publishing
 
                 SyncLog.LogEvent(EventType.INFORMATION, "KenticoKontentPublishing", "UPSERTRELATIONSHIPSSNIPPET");
 
-                var cloudSnippet = await GetSnippet(RELATED_PAGES_GUID);
-                if (cloudSnippet != null)
+                var kontentSnippet = await GetSnippet(RELATED_PAGES_GUID);
+                if (kontentSnippet != null)
                 {
-                    await PatchRelationshipsSnippet(cloudSnippet);
+                    await PatchRelationshipsSnippet(kontentSnippet);
                 }
                 else
                 {
@@ -175,7 +175,7 @@ namespace Kentico.EMS.Kontent.Publishing
             }
         }
 
-        private async Task PatchRelationshipsSnippet(SnippetData cloudSnippet)
+        private async Task PatchRelationshipsSnippet(SnippetData kontentSnippet)
         {
             try
             {
@@ -184,16 +184,15 @@ namespace Kentico.EMS.Kontent.Publishing
                 var externalId = GetSnippetExternalId(RELATED_PAGES_GUID);
                 var endpoint = $"/snippets/external-id/{HttpUtility.UrlEncode(externalId)}";
 
-                var removeAllExisting = cloudSnippet.Elements.Select(element => new
+                var removeAllExisting = kontentSnippet.Elements.Select(element => new
                 {
                     op = "remove",
-                    reference = new { id = element.Id }
+                    path = $"/elements/id:{element.Id}"
                 });
                 var addAllCurrent = GetRelationshipElements().Select(element => new
                 {
                     op = "addInto",
-                    reference = new { id = cloudSnippet.Id },
-                    property_name = "elements",
+                    path = "/elements",
                     value = element
                 });
                 var payload = removeAllExisting.AsEnumerable<object>().Concat(addAllCurrent).ToList();
@@ -366,10 +365,10 @@ namespace Kentico.EMS.Kontent.Publishing
             {
                 SyncLog.LogEvent(EventType.INFORMATION, "KenticoKontentPublishing", "SYNCCONTENTTYPE", contentType.ClassDisplayName);
 
-                var cloudContentType = await GetContentType(contentType);
-                if (cloudContentType != null)
+                var kontentContentType = await GetContentType(contentType);
+                if (kontentContentType != null)
                 {
-                    await PatchContentType(cloudContentType, contentType);
+                    await PatchContentType(kontentContentType, contentType);
                 }
                 else
                 {
@@ -437,8 +436,8 @@ namespace Kentico.EMS.Kontent.Publishing
                         type = GetElementType(field.DataType),
                         options = (field.DataType == FieldDataType.Binary)
                             ? new[] {
-                                        new MultipleChoiceElementOption { name = "True" },
-                                        new MultipleChoiceElementOption { name = "False" }
+                                new MultipleChoiceElementOption { name = "True" },
+                                new MultipleChoiceElementOption { name = "False" }
                             }
                             : null,
                     };
@@ -510,7 +509,7 @@ namespace Kentico.EMS.Kontent.Publishing
             }
         }
 
-        public async Task PatchContentType(ContentTypeData cloudContentType, DataClassInfo contentType)
+        public async Task PatchContentType(ContentTypeData kontentContentType, DataClassInfo contentType)
         {
             try
             {
@@ -519,16 +518,15 @@ namespace Kentico.EMS.Kontent.Publishing
                 var externalId = GetPageTypeExternalId(contentType.ClassGUID);
                 var endpoint = $"/types/external-id/{HttpUtility.UrlEncode(externalId)}";
 
-                var removeAllExisting = cloudContentType.Elements.Select(element => new
+                var removeAllExisting = kontentContentType.Elements.Select(element => new
                 {
                     op = "remove",
-                    reference = new { id = element.Id }
+                    path = $"/elements/id:{element.Id}"
                 });
                 var addAllCurrent = GetContentTypeElements(contentType).Select(element => new
                 {
                     op = "addInto",
-                    reference = new { id = cloudContentType.Id },
-                    property_name = "elements",
+                    path = "/elements",
                     value = element
                 });
                 var payload = removeAllExisting

--- a/Kentico.KontentPublishing/Sync/ContentTypeSync.cs
+++ b/Kentico.KontentPublishing/Sync/ContentTypeSync.cs
@@ -680,10 +680,9 @@ namespace Kentico.EMS.Kontent.Publishing
 
         private async Task<List<Guid>> GetAllContentTypeIds(string continuationToken = null)
         {
-            var query = (continuationToken != null) ? "?continuationToken=" + HttpUtility.UrlEncode(continuationToken) : "";
-            var itemsEndpoint = $"/types{query}";
+            var itemsEndpoint = $"/types";
 
-            var response = await ExecuteWithResponse<ContentTypesResponse>(itemsEndpoint, HttpMethod.Get);
+            var response = await ExecuteWithResponse<ContentTypesResponse>(itemsEndpoint, HttpMethod.Get, continuationToken);
             if (response == null)
             {
                 return new List<Guid>();
@@ -743,10 +742,9 @@ namespace Kentico.EMS.Kontent.Publishing
 
         private async Task<List<Guid>> GetAllContentTypeSnippetIds(string continuationToken = null)
         {
-            var query = (continuationToken != null) ? "?continuationToken=" + HttpUtility.UrlEncode(continuationToken) : "";
-            var endpoint = $"/snippets{query}";
+            var endpoint = $"/snippets";
 
-            var response = await ExecuteWithResponse<SnippetsResponse>(endpoint, HttpMethod.Get);
+            var response = await ExecuteWithResponse<SnippetsResponse>(endpoint, HttpMethod.Get, continuationToken);
             if (response == null)
             {
                 return new List<Guid>();

--- a/Kentico.KontentPublishing/Sync/ContentTypeSync.cs
+++ b/Kentico.KontentPublishing/Sync/ContentTypeSync.cs
@@ -296,12 +296,7 @@ namespace Kentico.EMS.Kontent.Publishing
         {
             SyncLog.Log("Synchronizing content types");
 
-            var contentTypes = DataClassInfoProvider.GetClasses()
-                .WhereEquals("ClassIsDocumentType", true)
-                .WhereIn(
-                    "ClassID",
-                    ClassSiteInfoProvider.GetClassSites().OnSite(Settings.Sitename).Column("ClassID")
-                );
+            var contentTypes = GetSynchronizedContentTypes();
 
             var index = 0;
 
@@ -318,6 +313,13 @@ namespace Kentico.EMS.Kontent.Publishing
 
                 await SyncContentType(contentType);
             }
+        }
+
+        public ObjectQuery<DataClassInfo> GetSynchronizedContentTypes()
+        {
+            return DataClassInfoProvider.GetClasses()
+                .WhereEquals("ClassIsDocumentType", true)
+                .OnSite(Settings.Sitename);
         }
 
         private async Task<ContentTypeData> GetContentType(DataClassInfo contentType)

--- a/Kentico.KontentPublishing/Sync/ContentTypeSync.cs
+++ b/Kentico.KontentPublishing/Sync/ContentTypeSync.cs
@@ -18,6 +18,8 @@ namespace Kentico.EMS.Kontent.Publishing
 {
     internal partial class ContentTypeSync : SyncBase
     {
+        private readonly int ELEMENT_MAXLENGTH = 50;
+
         private PageSync _pageSync;
 
         public static readonly string[] UsedRelationshipNameColumns = new[]
@@ -32,7 +34,6 @@ namespace Kentico.EMS.Kontent.Publishing
             "ClassName",
             "ClassFormDefinition",
         };
-        private readonly int ELEMENT_MAXLENGTH;
 
         public ContentTypeSync(SyncSettings settings, PageSync pageSync) : base(settings)
         {
@@ -331,8 +332,7 @@ namespace Kentico.EMS.Kontent.Publishing
                 .WhereIn(
                     "ClassID",
                     ClassSiteInfoProvider.GetClassSites().OnSite(Settings.Sitename).Column("ClassID")
-                )
-                .WhereNotEquals("ClassName", "CMS.Root");
+                );
 
             var index = 0;
 
@@ -482,7 +482,10 @@ namespace Kentico.EMS.Kontent.Publishing
                         name = GetElementName(field).LimitedTo(ELEMENT_MAXLENGTH),
                         codename = field.Name.ToLower().LimitedTo(ELEMENT_MAXLENGTH),
                         guidelines = GetElementGuidelines(field),
-                        is_required = !field.AllowEmpty,
+                        is_required =
+                            !field.AllowEmpty &&
+                            // Exception - Allow empty value for root document name
+                            ((field.Name.ToLowerInvariant() != "documentname") || (contentType.ClassName.ToLowerInvariant() != "cms.root")),
                         type = GetElementType(field.DataType),
                         options = (field.DataType == FieldDataType.Binary)
                             ? new[] {

--- a/Kentico.KontentPublishing/Sync/LanguageSync.cs
+++ b/Kentico.KontentPublishing/Sync/LanguageSync.cs
@@ -99,7 +99,7 @@ namespace Kentico.EMS.Kontent.Publishing
                 var payload = new
                 {
                     name = culture.CultureName,
-                    codename = culture.CultureCode,
+                    codename = culture.CultureCode.ToLower(),
                     external_id = externalId,
                     is_active = true,
                     // Default language is always empty, and no fallback is used as a result

--- a/Kentico.KontentPublishing/Sync/LanguageSync.cs
+++ b/Kentico.KontentPublishing/Sync/LanguageSync.cs
@@ -40,10 +40,9 @@ namespace Kentico.EMS.Kontent.Publishing
 
         private async Task<List<LanguageData>> GetAllLanguages(string continuationToken = null)
         {
-            var query = (continuationToken != null) ? "?continuationToken=" + HttpUtility.UrlEncode(continuationToken) : "";
-            var endpoint = $"/languages{query}";
+            var endpoint = $"/languages";
 
-            var response = await ExecuteWithResponse<LanguagesResponse>(endpoint, HttpMethod.Get);
+            var response = await ExecuteWithResponse<LanguagesResponse>(endpoint, HttpMethod.Get, continuationToken);
             if (response == null)
             {
                 return new List<LanguageData>();

--- a/Kentico.KontentPublishing/Sync/LanguageSync.cs
+++ b/Kentico.KontentPublishing/Sync/LanguageSync.cs
@@ -64,13 +64,13 @@ namespace Kentico.EMS.Kontent.Publishing
             return languages;
         }
 
-        public async Task SyncCultures(CancellationToken? cancellation = null)
+        public async Task SyncCultures()
         {
             try
             {
                 SyncLog.Log("Synchronizing cultures");
 
-                SyncLog.LogEvent(EventType.INFORMATION, "KenticoKontentPublishing", "ENSURECULTURES");
+                SyncLog.LogEvent(EventType.INFORMATION, "KenticoKontentPublishing", "SYNCCULTURES");
 
                 var existingLanguages = await GetAllLanguages();
                 var cultures = CultureSiteInfoProvider.GetSiteCultures(Settings.Sitename).ToList();
@@ -101,7 +101,7 @@ namespace Kentico.EMS.Kontent.Publishing
             }
             catch (Exception ex)
             {
-                SyncLog.LogException("KenticoKontentPublishing", "ENSURECULTURES", ex);
+                SyncLog.LogException("KenticoKontentPublishing", "SYNCCULTURES", ex);
                 throw;
             }
         }
@@ -139,7 +139,7 @@ namespace Kentico.EMS.Kontent.Publishing
             }
             catch (Exception ex)
             {
-                SyncLog.LogException("KenticoKontentPublishing", "CREATECULTURE", ex);
+                SyncLog.LogException("KenticoKontentPublishing", "DEACTIVATELANGUAGE", ex);
                 throw;
             }
         }
@@ -148,7 +148,7 @@ namespace Kentico.EMS.Kontent.Publishing
         {
             try
             {
-                SyncLog.LogEvent(EventType.INFORMATION, "KenticoKontentPublishing", "PATCHDEFAULTCULTURE");
+                SyncLog.LogEvent(EventType.INFORMATION, "KenticoKontentPublishing", "PATCHDEFAULTLANGUAGE");
 
                 var endpoint = $"/languages/{Guid.Empty}";
 
@@ -171,7 +171,7 @@ namespace Kentico.EMS.Kontent.Publishing
             }
             catch (Exception ex)
             {
-                SyncLog.LogException("KenticoKontentPublishing", "CREATECULTURE", ex);
+                SyncLog.LogException("KenticoKontentPublishing", "PATCHDEFAULTLANGUAGE", ex);
                 throw;
             }
         }
@@ -180,7 +180,7 @@ namespace Kentico.EMS.Kontent.Publishing
         {
             try
             {
-                SyncLog.LogEvent(EventType.INFORMATION, "KenticoKontentPublishing", "PATCHCULTURE", $"{culture.CultureName} ({culture.CultureCode})");
+                SyncLog.LogEvent(EventType.INFORMATION, "KenticoKontentPublishing", "PATCHLANGUAGE", $"{culture.CultureName} ({culture.CultureCode})");
 
                 var externalId = GetLanguageExternalId(culture.CultureGUID);
                 var endpoint = $"/languages/external-id/{externalId}";
@@ -210,7 +210,7 @@ namespace Kentico.EMS.Kontent.Publishing
             }
             catch (Exception ex)
             {
-                SyncLog.LogException("KenticoKontentPublishing", "CREATECULTURE", ex);
+                SyncLog.LogException("KenticoKontentPublishing", "PATCHLANGUAGE", ex);
                 throw;
             }
         }
@@ -219,7 +219,7 @@ namespace Kentico.EMS.Kontent.Publishing
         {
             try
             {
-                SyncLog.LogEvent(EventType.INFORMATION, "KenticoKontentPublishing", "CREATECULTURE", $"{culture.CultureName} ({culture.CultureCode})");
+                SyncLog.LogEvent(EventType.INFORMATION, "KenticoKontentPublishing", "CREATELANGUAGE", $"{culture.CultureName} ({culture.CultureCode})");
 
                 var externalId = GetLanguageExternalId(culture.CultureGUID);
                 var endpoint = $"/languages";
@@ -231,6 +231,7 @@ namespace Kentico.EMS.Kontent.Publishing
                     external_id = externalId,
                     is_active = true,
                     // Default language is always empty, and no fallback is used as a result
+                    // If Kontent supported language without fallback, this needs to be updated
                     // fallback_language = new { id = Guid.Empty }
                 };
 
@@ -238,7 +239,7 @@ namespace Kentico.EMS.Kontent.Publishing
             }
             catch (Exception ex)
             {
-                SyncLog.LogException("KenticoKontentPublishing", "CREATECULTURE", ex);
+                SyncLog.LogException("KenticoKontentPublishing", "CREATELANGUAGE", ex);
                 throw;
             }
         }

--- a/Kentico.KontentPublishing/Sync/LinkTranslator.cs
+++ b/Kentico.KontentPublishing/Sync/LinkTranslator.cs
@@ -1,0 +1,128 @@
+﻿using CMS.Base.Web.UI;
+using CMS.SiteProvider;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Text.RegularExpressions;
+using System.Threading.Tasks;
+using System.Web;
+
+namespace Kentico.EMS.Kontent.Publishing
+{
+    internal class LinkTranslator
+    {
+        private readonly SyncSettings _settings;
+        private readonly AssetSync _assetSync;
+
+        public LinkTranslator(SyncSettings settings, AssetSync assetSync)
+        {
+            _settings = settings;
+            _assetSync = assetSync;
+        }
+
+        private string TranslateMediaQuery(string query)
+        {
+            if (!string.IsNullOrEmpty(query))
+            {
+                var newQueryParams = new List<KeyValuePair<string, string>>();
+
+                var queryParams = HttpUtility.ParseQueryString(HttpUtility.HtmlDecode(query));
+                foreach (var key in queryParams.AllKeys)
+                {
+                    var newQueryParam = TranslateQueryParam(key, queryParams[key]);
+                    if (newQueryParam != null)
+                    {
+                        newQueryParams.AddRange(newQueryParam);
+                    }
+                }
+
+                if (newQueryParams.Count > 0)
+                {
+                    var newQuery = $"?{ string.Join("&", newQueryParams.Select(param => $"{HttpUtility.UrlEncode(param.Key)}={HttpUtility.UrlEncode(param.Value)}"))}";
+
+                    return newQuery;
+                }
+            }
+
+            return null;
+        }
+
+        private static readonly Regex UrlAttributeRegEx = new Regex("(?<start>\\b(href|src)=\")(?<url>[^\"?]+)(?<query>\\?[^\"]+)?(?<end>\")");
+
+        private async Task<string> ReplaceMediaLink(Match match)
+        {
+            var start = Convert.ToString(match.Groups["start"]);
+            var url = HttpUtility.HtmlDecode(Convert.ToString(match.Groups["url"]));
+            var query = HttpUtility.HtmlDecode(Convert.ToString(match.Groups["query"]));
+            var end = Convert.ToString(match.Groups["end"]);
+
+            try
+            {
+                // We need to set current site before every call to GetMediaData to avoid null reference
+                SiteContext.CurrentSiteName = _settings.Sitename;
+                var data = CMSDialogHelper.GetMediaData(url, _settings.Sitename);
+                if (data != null)
+                {
+                    switch (data.SourceType)
+                    {
+                        case MediaSourceEnum.Attachment:
+                        case MediaSourceEnum.DocumentAttachments:
+                            {
+                                var assetUrl = await _assetSync.GetAssetUrl("attachment", data.AttachmentGuid);
+                                var newQuery = TranslateMediaQuery(query);
+
+                                return $"{start}{HttpUtility.HtmlEncode(assetUrl)}{HttpUtility.HtmlEncode(newQuery)}{end}";
+                            }
+
+                        case MediaSourceEnum.MediaLibraries:
+                            {
+                                var assetUrl = await _assetSync.GetAssetUrl("media", data.MediaFileGuid);
+                                var newQuery = TranslateMediaQuery(query);
+
+                                return $"{start}{HttpUtility.HtmlEncode(assetUrl)}{HttpUtility.HtmlEncode(newQuery)}{end}";
+                            }
+                    }
+                }
+            }
+            catch (Exception ex)
+            {
+                SyncLog.LogException("KenticoKontentPublishing", "TRANSLATEURL", ex, 0, $"Failed to replace media URL '{url + query}', keeping the original URL.");
+            }
+
+            // Keep as it is if translation is not successful, only resolve to absolute URL if needed
+            if (url.StartsWith("~"))
+            {
+                return $"{start}{HttpUtility.HtmlEncode(_settings.WebRoot)}{HttpUtility.HtmlEncode(url.Substring(1))}{HttpUtility.HtmlEncode(query)}{end}";
+            }
+            return match.ToString();
+        }
+
+        private KeyValuePair<string, string>[] TranslateQueryParam(string key, string value)
+        {
+            switch (key.ToLowerInvariant())
+            {
+                case "width":
+                    return new[] { new KeyValuePair<string, string>("w", value) };
+
+                case "height":
+                    return new[] { new KeyValuePair<string, string>("h", value) };
+
+                case "maxsidesize":
+                    return new[] {
+                        new KeyValuePair<string, string>("w", value),
+                        new KeyValuePair<string, string>("h", value),
+                        new KeyValuePair<string, string>("fit", "clip")
+                    };
+
+                default:
+                    return null;
+            }
+        }
+
+        public async Task<string> TranslateLinks(string content)
+        {
+            return await UrlAttributeRegEx.ReplaceAsync(content, ReplaceMediaLink);
+        }
+    }
+}

--- a/Kentico.KontentPublishing/Sync/NodeWithoutPublishFrom.cs
+++ b/Kentico.KontentPublishing/Sync/NodeWithoutPublishFrom.cs
@@ -7,9 +7,8 @@ namespace Kentico.EMS.Kontent.Publishing
 {
     internal class NodeWithoutPublishFrom : IDataContainer
     {
-        private TreeNode _node;
-
-
+        private readonly TreeNode _node;
+        
         public NodeWithoutPublishFrom(TreeNode node)
         {
             _node = node;
@@ -30,8 +29,7 @@ namespace Kentico.EMS.Kontent.Publishing
 
         public object GetValue(string columnName)
         {
-            object value;
-            TryGetValue(columnName, out value);
+            TryGetValue(columnName, out object value);
 
             return value;
         }

--- a/Kentico.KontentPublishing/Sync/NodeWithoutPublishFrom.cs
+++ b/Kentico.KontentPublishing/Sync/NodeWithoutPublishFrom.cs
@@ -1,7 +1,7 @@
-﻿using CMS.DocumentEngine;
-using CMS.Base;
+﻿using System.Collections.Generic;
 
-using System.Collections.Generic;
+using CMS.DocumentEngine;
+using CMS.Base;
 
 namespace Kentico.EMS.Kontent.Publishing
 {

--- a/Kentico.KontentPublishing/Sync/PageSync.cs
+++ b/Kentico.KontentPublishing/Sync/PageSync.cs
@@ -776,10 +776,9 @@ LEFT JOIN CMS_RelationshipName RN ON RNS.RelationshipNameID = RNS.RelationshipNa
 
         private async Task<List<Guid>> GetAllItemIds(Guid? contentTypeId, string continuationToken = null)
         {
-            var query = (continuationToken != null) ? "?continuationToken=" + HttpUtility.UrlEncode(continuationToken) : "";
-            var endpoint = $"/items{query}";
+            var endpoint = $"/items";
 
-            var response = await ExecuteWithResponse<ItemsResponse>(endpoint, HttpMethod.Get);
+            var response = await ExecuteWithResponse<ItemsResponse>(endpoint, HttpMethod.Get, continuationToken);
             if (response == null)
             {
                 return new List<Guid>();

--- a/Kentico.KontentPublishing/Sync/PageSync.cs
+++ b/Kentico.KontentPublishing/Sync/PageSync.cs
@@ -23,12 +23,14 @@ namespace Kentico.EMS.Kontent.Publishing
         private const int ITEM_NAME_MAXLENGTH = 50;
 
         private readonly AssetSync _assetSync;
+        private readonly ContentTypeSync _contentTypeSync;
         private readonly LinkTranslator _linkTranslator;
         private readonly TreeProvider _tree = new TreeProvider();
 
-        public PageSync(SyncSettings settings, AssetSync assetSync) : base(settings)
+        public PageSync(SyncSettings settings, AssetSync assetSync, ContentTypeSync contentTypeSync) : base(settings)
         {
             _assetSync = assetSync;
+            _contentTypeSync = contentTypeSync;
             _linkTranslator = new LinkTranslator(settings, assetSync);
         }
 
@@ -650,9 +652,7 @@ LEFT JOIN CMS_Tree T ON R.RightNodeID = T.NodeID
         {
             SyncLog.Log("Synchronizing pages");
 
-            var contentTypes = DataClassInfoProvider.GetClasses()
-                .WhereEquals("ClassIsDocumentType", true)
-                .OnSite(Settings.Sitename);
+            var contentTypes = _contentTypeSync.GetSynchronizedContentTypes();
 
             var index = 0;
 

--- a/Kentico.KontentPublishing/Sync/PageSync.cs
+++ b/Kentico.KontentPublishing/Sync/PageSync.cs
@@ -591,7 +591,7 @@ LEFT JOIN CMS_Tree T ON R.RightNodeID = T.NodeID
                 case FieldDataType.Boolean:
                     if (value == null)
                     {
-                        return null;
+                        return new object[0];
                     }
                     return (bool)value
                         ? new[] { new { codename = "true" } }

--- a/Kentico.KontentPublishing/Sync/PageSync.cs
+++ b/Kentico.KontentPublishing/Sync/PageSync.cs
@@ -268,7 +268,7 @@ namespace Kentico.EMS.Kontent.Publishing
             {
                 element = new
                 {
-                    external_id = ContentTypeSync.GetFieldExternalId(contentType.ClassGUID, ContentTypeSync.CATEGORIES_GUID)
+                    external_id = ContentTypeSync.GetFieldExternalId(contentType.ClassGUID, TaxonomySync.CATEGORIES_GUID)
                 },
                 value = (object)GetCategoryGuids(node).Select(guid => new {
                     external_id = TaxonomySync.GetCategoryTermExternalId(guid)

--- a/Kentico.KontentPublishing/Sync/PageSync.cs
+++ b/Kentico.KontentPublishing/Sync/PageSync.cs
@@ -16,7 +16,6 @@ using CMS.Relationships;
 using CMS.SiteProvider;
 using CMS.Base.Web.UI;
 using CMS.Localization;
-using CMS.Taxonomy;
 
 namespace Kentico.EMS.Kontent.Publishing
 {
@@ -126,6 +125,35 @@ namespace Kentico.EMS.Kontent.Publishing
                     return false;
                 }
 
+                throw;
+            }
+        }
+
+        public async Task DeletePages(CancellationToken? cancellation, ICollection<TreeNode> nodes, string info)
+        {
+            try
+            {
+                SyncLog.LogEvent(EventType.INFORMATION, "KenticoKontentPublishing", "DELETEPAGES", info);
+
+                var index = 0;
+
+                foreach (var node in nodes)
+                {
+                    if (cancellation?.IsCancellationRequested == true)
+                    {
+                        return;
+                    }
+
+                    index++;
+
+                    SyncLog.Log($"Deleting page {node.NodeAliasPath} ({index}/{nodes.Count})");
+
+                    await DeletePage(cancellation, node);
+                }
+            }
+            catch (Exception ex)
+            {
+                SyncLog.LogException("KenticoKontentPublishing", "DELETEPAGES", ex);
                 throw;
             }
         }
@@ -423,20 +451,11 @@ LEFT JOIN CMS_RelationshipName RN ON RNS.RelationshipNameID = RNS.RelationshipNa
 
         public async Task SyncPageWithAllData(CancellationToken? cancellation, TreeNode node)
         {
-            await SyncPage(cancellation, node);
             if (cancellation?.IsCancellationRequested == true)
             {
                 await _assetSync.SyncAllAttachments(cancellation, node);
             }
-        }
-        
-        public async Task DeletePageWithAllData(CancellationToken? cancellation, TreeNode node)
-        {
-            await _assetSync.DeleteAllAttachments(cancellation, node);
-            if (cancellation?.IsCancellationRequested == true)
-            {
-                await DeletePage(cancellation, node);
-            }
+            await SyncPage(cancellation, node);
         }
 
         public async Task SyncPage(CancellationToken? cancellation, TreeNode node)

--- a/Kentico.KontentPublishing/Sync/PageSync.cs
+++ b/Kentico.KontentPublishing/Sync/PageSync.cs
@@ -337,7 +337,7 @@ LEFT JOIN CMS_RelationshipName RN ON RNS.RelationshipNameID = RNS.RelationshipNa
 
             await ExecuteWithoutResponse(endpoint, HttpMethod.Put, payload, true);
         }
-        
+
         private async Task PublishVariant(TreeNode node, DateTime? publishWhen)
         {
             var variantEndpoint = GetVariantEndpoint(node);
@@ -418,6 +418,24 @@ LEFT JOIN CMS_RelationshipName RN ON RNS.RelationshipNameID = RNS.RelationshipNa
                 {
                     await SyncPage(cancellation, node);
                 }
+            }
+        }
+
+        public async Task SyncPageWithAllData(CancellationToken? cancellation, TreeNode node)
+        {
+            await SyncPage(cancellation, node);
+            if (cancellation?.IsCancellationRequested == true)
+            {
+                await _assetSync.SyncAllAttachments(cancellation, node);
+            }
+        }
+        
+        public async Task DeletePageWithAllData(CancellationToken? cancellation, TreeNode node)
+        {
+            await _assetSync.DeleteAllAttachments(cancellation, node);
+            if (cancellation?.IsCancellationRequested == true)
+            {
+                await DeletePage(cancellation, node);
             }
         }
 

--- a/Kentico.KontentPublishing/Sync/Purge.cs
+++ b/Kentico.KontentPublishing/Sync/Purge.cs
@@ -1,9 +1,0 @@
-﻿namespace Kentico.EMS.Kontent.Publishing.Sync
-{
-    class Purge : SyncBase
-    {
-        public Purge(SyncSettings settings) : base(settings)
-        {
-        }
-    }
-}

--- a/Kentico.KontentPublishing/Sync/StringExtensions.cs
+++ b/Kentico.KontentPublishing/Sync/StringExtensions.cs
@@ -1,0 +1,14 @@
+﻿namespace Kentico.EMS.Kontent.Publishing
+{
+    static class StringExtensions
+    {
+        public static string LimitedTo(this string value, int maxChars)
+        {
+            if (value.Length > maxChars)
+            {
+                return value.Substring(0, maxChars);
+            }
+            return value;
+        }
+    }
+}

--- a/Kentico.KontentPublishing/Sync/SyncBase.cs
+++ b/Kentico.KontentPublishing/Sync/SyncBase.cs
@@ -69,10 +69,14 @@ namespace Kentico.EMS.Kontent.Publishing
             _settings = settings;
         }
 
-        private HttpRequestMessage CreateMessage(string endpointUrl, HttpMethod method, object payload = null, bool includeNullValues = false)
+        private HttpRequestMessage CreateMessage(string endpointUrl, HttpMethod method, string continuationToken = null, object payload = null, bool includeNullValues = false)
         {
             var message = new HttpRequestMessage(method, endpointUrl);
             message.Headers.Authorization = new AuthenticationHeaderValue("Bearer", _settings.CMApiKey);
+            if (continuationToken != null)
+            {
+                message.Headers.Add("x-continuation", continuationToken);
+            }
 
             if (payload != null)
             {
@@ -126,17 +130,17 @@ namespace Kentico.EMS.Kontent.Publishing
         {
             var endpointUrl = $"{ApiRoot}/projects/{_settings.ProjectId}{endpoint}";
 
-            using (var response = await SendMessage(() => CreateMessage(endpointUrl, method, payload, includeNullValues)))
+            using (var response = await SendMessage(() => CreateMessage(endpointUrl, method, null, payload, includeNullValues)))
             {
                 await HandleStatusCode(response);
             }
         }
 
-        protected async Task<T> ExecuteWithResponse<T>(string endpoint, HttpMethod method, object payload = null, bool includeNullValues = false) where T : class
+        protected async Task<T> ExecuteWithResponse<T>(string endpoint, HttpMethod method, string continuationToken = null, object payload = null, bool includeNullValues = false) where T : class
         {
             var endpointUrl = $"{ApiRoot}/projects/{_settings.ProjectId}{endpoint}";
 
-            using (var response = await SendMessage(() => CreateMessage(endpointUrl, method, payload, includeNullValues)))
+            using (var response = await SendMessage(() => CreateMessage(endpointUrl, method, continuationToken, payload, includeNullValues)))
             {
                 // 404 response is valid response for GET requests
                 if ((method == HttpMethod.Get) && (response.StatusCode == HttpStatusCode.NotFound))

--- a/Kentico.KontentPublishing/Sync/SyncBase.cs
+++ b/Kentico.KontentPublishing/Sync/SyncBase.cs
@@ -15,6 +15,8 @@ namespace Kentico.EMS.Kontent.Publishing
 {
     internal class SyncBase
     {
+        protected static HttpMethod PATCH = new HttpMethod("PATCH");
+
         private const string ApiRoot = "https://manage.kontent.ai/v2";
         private SyncSettings _settings;
 

--- a/Kentico.KontentPublishing/Sync/SyncBase.cs
+++ b/Kentico.KontentPublishing/Sync/SyncBase.cs
@@ -15,6 +15,7 @@ namespace Kentico.EMS.Kontent.Publishing
 {
     internal class SyncBase
     {
+        private const string ApiRoot = "https://manage.kontent.ai/v2";
         private SyncSettings _settings;
 
         HttpClient _client = new HttpClient();
@@ -91,7 +92,7 @@ namespace Kentico.EMS.Kontent.Publishing
 
                 throw new HttpException(
                     (int)response.StatusCode,
-                    $"Request to Kentico Cloud failed with status code {response.StatusCode}, response content:\n\n{content}"
+                    $"Request to Kentico Kontent failed with status code {response.StatusCode}, operation:\n{response.RequestMessage.Method} {response.RequestMessage.RequestUri}, response content:\n\n{content}"
                 );
             }
         }
@@ -120,7 +121,7 @@ namespace Kentico.EMS.Kontent.Publishing
 
         protected async Task ExecuteWithoutResponse(string endpoint, HttpMethod method, object payload = null, bool includeNullValues = false)
         {
-            var endpointUrl = $"https://manage.kenticocloud.com/v2/projects/{_settings.ProjectId}{endpoint}";
+            var endpointUrl = $"{ApiRoot}/projects/{_settings.ProjectId}{endpoint}";
 
             using (var response = await SendMessage(() => CreateMessage(endpointUrl, method, payload, includeNullValues)))
             {
@@ -130,7 +131,7 @@ namespace Kentico.EMS.Kontent.Publishing
 
         protected async Task<T> ExecuteWithResponse<T>(string endpoint, HttpMethod method, object payload = null, bool includeNullValues = false) where T : class
         {
-            var endpointUrl = $"https://manage.kenticocloud.com/v2/projects/{_settings.ProjectId}{endpoint}";
+            var endpointUrl = $"{ApiRoot}/projects/{_settings.ProjectId}{endpoint}";
 
             using (var response = await SendMessage(() => CreateMessage(endpointUrl, method, payload, includeNullValues)))
             {
@@ -163,7 +164,7 @@ namespace Kentico.EMS.Kontent.Publishing
 
         protected async Task<T> ExecuteUploadWithResponse<T>(string endpoint, byte[] data, string contentType) where T : class
         {
-            var endpointUrl = $"https://manage.kenticocloud.com/v2/projects/{_settings.ProjectId}{endpoint}";
+            var endpointUrl = $"{ApiRoot}/projects/{_settings.ProjectId}{endpoint}";
 
             using (var response = await SendMessage(() => CreateUploadMessage(endpointUrl, data, contentType)))
             {

--- a/Kentico.KontentPublishing/Sync/SyncBase.cs
+++ b/Kentico.KontentPublishing/Sync/SyncBase.cs
@@ -5,6 +5,7 @@ using System.Net.Http.Headers;
 using System.Text;
 using System.Threading.Tasks;
 using System.Web;
+
 using CMS.EventLog;
 using CMS.SiteProvider;
 

--- a/Kentico.KontentPublishing/Sync/SyncBase.cs
+++ b/Kentico.KontentPublishing/Sync/SyncBase.cs
@@ -19,9 +19,9 @@ namespace Kentico.EMS.Kontent.Publishing
         protected static HttpMethod PATCH = new HttpMethod("PATCH");
 
         private const string ApiRoot = "https://manage.kontent.ai/v2";
-        private SyncSettings _settings;
 
-        HttpClient _client = new HttpClient();
+        private readonly SyncSettings _settings;
+        private readonly HttpClient _client = new HttpClient();
                
         public SyncSettings Settings
         {
@@ -44,23 +44,21 @@ namespace Kentico.EMS.Kontent.Publishing
         public const int MAX_RETRIES = 5;
 
         // Only HTTP status codes are handled with retries, not exceptions.
-        private IAsyncPolicy<HttpResponseMessage> _retryPolicy = Policy
+        private readonly IAsyncPolicy<HttpResponseMessage> _retryPolicy = Policy
             .HandleResult<HttpResponseMessage>(result => Enum.IsDefined(typeof(RetryHttpCode), (RetryHttpCode)result.StatusCode))
             .WaitAndRetryAsync(
                 MAX_RETRIES,
                 retryAttempt => TimeSpan.FromMilliseconds(Math.Pow(2, retryAttempt) * 100)
             );
 
-        private JsonSerializerSettings _serializeSettings = new JsonSerializerSettings
+        private readonly JsonSerializerSettings _serializeSettings = new JsonSerializerSettings
         {
             NullValueHandling = NullValueHandling.Ignore,
-            //Converters = new List<JsonConverter> { new DecimalObjectConverter() }
         };
 
-        private JsonSerializerSettings _serializeSettingsKeepNull = new JsonSerializerSettings
+        private readonly JsonSerializerSettings _serializeSettingsKeepNull = new JsonSerializerSettings
         {
             NullValueHandling = NullValueHandling.Include,
-            //Converters = new List<JsonConverter> { new DecimalObjectConverter() }
         };
 
 

--- a/Kentico.KontentPublishing/Sync/SyncSettings.cs
+++ b/Kentico.KontentPublishing/Sync/SyncSettings.cs
@@ -17,8 +17,7 @@ namespace Kentico.EMS.Kontent.Publishing
 
         public void LoadFromConfig()
         {
-            Guid projectId;
-            Guid.TryParse(ConfigurationManager.AppSettings.Get("KCSyncProjectID"), out projectId);
+            Guid.TryParse(ConfigurationManager.AppSettings.Get("KCSyncProjectID"), out Guid projectId);
             ProjectId = projectId;
 
             CMApiKey = ConfigurationManager.AppSettings.Get("KCSyncCMAPIKey");

--- a/Kentico.KontentPublishing/Sync/TaxonomySync.cs
+++ b/Kentico.KontentPublishing/Sync/TaxonomySync.cs
@@ -151,13 +151,13 @@ namespace Kentico.EMS.Kontent.Publishing
             var query = (continuationToken != null) ? "?continuationToken=" + HttpUtility.UrlEncode(continuationToken) : "";
             var endpoint = $"/taxonomies{query}";
 
-            var response = await ExecuteWithResponse<List<TaxonomyData>>(endpoint, HttpMethod.Get);
+            var response = await ExecuteWithResponse<TaxonomyResponse>(endpoint, HttpMethod.Get);
             if (response == null)
             {
                 return new List<Guid>();
             }
 
-            var ids = response.Select(item => item.Id);
+            var ids = response.Taxonomies.Select(item => item.Id);
 
             return ids.ToList();
         }

--- a/Kentico.KontentPublishing/Sync/TaxonomySync.cs
+++ b/Kentico.KontentPublishing/Sync/TaxonomySync.cs
@@ -159,10 +159,9 @@ namespace Kentico.EMS.Kontent.Publishing
         
         private async Task<List<Guid>> GetAllTaxonomyIds(string continuationToken = null)
         {
-            var query = (continuationToken != null) ? "?continuationToken=" + HttpUtility.UrlEncode(continuationToken) : "";
-            var endpoint = $"/taxonomies{query}";
+            var endpoint = $"/taxonomies";
 
-            var response = await ExecuteWithResponse<TaxonomyResponse>(endpoint, HttpMethod.Get);
+            var response = await ExecuteWithResponse<TaxonomyResponse>(endpoint, HttpMethod.Get, continuationToken);
             if (response == null)
             {
                 return new List<Guid>();

--- a/Kentico.KontentPublishing/Sync/TaxonomySync.cs
+++ b/Kentico.KontentPublishing/Sync/TaxonomySync.cs
@@ -14,6 +14,10 @@ namespace Kentico.EMS.Kontent.Publishing
 {
     internal partial class TaxonomySync : SyncBase
     {
+        public const string CATEGORIES = "Categories";
+        public static Guid CATEGORIES_GUID = new Guid("c13a89d6-c5a9-4c6c-bceb-e27bf04e26d3");
+
+
         public TaxonomySync(SyncSettings settings) : base(settings)
         {
         }
@@ -79,7 +83,7 @@ namespace Kentico.EMS.Kontent.Publishing
 
                 SyncLog.LogEvent(EventType.INFORMATION, "KenticoKontentPublishing", "DELETECATEGORIESTAXONOMY");
 
-                var externalId = GetTaxonomyExternalId(ContentTypeSync.CATEGORIES_GUID);
+                var externalId = GetTaxonomyExternalId(CATEGORIES_GUID);
                 var endpoint = $"/taxonomies/external-id/{HttpUtility.UrlEncode(externalId)}";
 
                 await ExecuteWithoutResponse(endpoint, HttpMethod.Delete);
@@ -105,7 +109,8 @@ namespace Kentico.EMS.Kontent.Publishing
         {
             return categories.Where(c => c.CategoryParentID == parentId).Select(category => new CategoryTerm()
             {
-                name = category.CategoryName,
+                name = category.CategoryDisplayName,
+                codename = category.CategoryName.ToLower(),
                 external_id = GetCategoryTermExternalId(category.CategoryGUID),
                 terms = GetCategoryTerms(categories, category.CategoryID)
             }).ToList();
@@ -123,12 +128,13 @@ namespace Kentico.EMS.Kontent.Publishing
                     .OrderBy("CategorySiteID", "CategoryOrder")
                     .TypedResult;
 
-                var externalId = GetTaxonomyExternalId(ContentTypeSync.CATEGORIES_GUID);
+                var externalId = GetTaxonomyExternalId(CATEGORIES_GUID);
                 var endpoint = $"/taxonomies";
 
                 var payload = new
                 {
                     name = "Categories",
+                    codename = CATEGORIES.ToLower(),
                     external_id = externalId,
                     terms = GetCategoryTerms(categories),
                 };

--- a/Kentico.KontentPublishing/Sync/TaxonomySync.cs
+++ b/Kentico.KontentPublishing/Sync/TaxonomySync.cs
@@ -60,13 +60,13 @@ namespace Kentico.EMS.Kontent.Publishing
             return category.CategorySiteID == siteId;
         }
         
-        public async Task SyncCategories(CancellationToken? cancellation = null)
+        public async Task SyncCategories()
         {
             try
             {
                 SyncLog.Log("Synchronizing categories");
 
-                SyncLog.LogEvent(EventType.INFORMATION, "KenticoKontentPublishing", "UPSERTCATEGORIESTAXONOMY");
+                SyncLog.LogEvent(EventType.INFORMATION, "KenticoKontentPublishing", "SYNCCATEGORIES");
 
                 // TODO - consider patch
                 await DeleteCategoriesTaxonomy();
@@ -74,7 +74,7 @@ namespace Kentico.EMS.Kontent.Publishing
             }
             catch (Exception ex)
             {
-                SyncLog.LogException("KenticoKontentPublishing", "UPSERTCATEGORIESTAXONOMY", ex);
+                SyncLog.LogException("KenticoKontentPublishing", "SYNCCATEGORIES", ex);
                 throw;
             }
         }
@@ -113,10 +113,10 @@ namespace Kentico.EMS.Kontent.Publishing
         {
             return categories.Where(c => c.CategoryParentID == parentId).Select(category => new CategoryTerm()
             {
-                name = category.CategoryDisplayName.LimitedTo(TAXONOMY_NAME_MAXLENGTH),
-                codename = category.CategoryName.ToLower().LimitedTo(TAXONOMY_CODENAME_MAXLENGTH),
-                external_id = GetCategoryTermExternalId(category.CategoryGUID),
-                terms = GetCategoryTerms(categories, category.CategoryID)
+                Name = category.CategoryDisplayName.LimitedTo(TAXONOMY_NAME_MAXLENGTH),
+                Codename = category.CategoryName.ToLower().LimitedTo(TAXONOMY_CODENAME_MAXLENGTH),
+                ExternalId = GetCategoryTermExternalId(category.CategoryGUID),
+                Terms = GetCategoryTerms(categories, category.CategoryID)
             }).ToList();
         }
             

--- a/README.md
+++ b/README.md
@@ -130,13 +130,6 @@ Delete the module Kentico Kontent Publishing from Kentico EMS Administration int
 
 Rebuild the solution(s).
 
-### Known issues and TODOs
-
-The module leverages Kentico Kontent Content Management API which is still in beta version.
-
-Some of the features will be finalized once the related parts of the API are finished, namely:
-* Content groups - Once they are supported by the CM API, target content type elements will be split to multiple tabs.
-
 ![Analytics](https://kentico-ga-beacon.azurewebsites.net/api/UA-69014260-4/Kentico/ems-module-kontent-publishing?pixel)
 
 ## [Questions & Support](https://github.com/Kentico/Home/blob/master/README.md)

--- a/README.md
+++ b/README.md
@@ -49,11 +49,11 @@ Create a **new empty project** in [Kentico Kontent](https://app.kontent.ai).
 Add the following keys to the web.config (or app.config) of your project(s)
 
 ```
-<add key="KCSyncSitename" value="<SITE CODE NAME>" />
-<add key="KCSyncWebRoot" value="<URL OF THE TARGET WEB SITE>" />
-<add key="KCSyncAssetsDomain" value="<KENTICO KONTENT ASSET DOMAIN>" />
-<add key="KCSyncProjectID" value="<YOUR PROJECT ID>" />
-<add key="KCSyncCMAPIKey" value="<YOUR CM API KEY>" />
+<add key="KCSyncSitename" value="[SITE CODE NAME]" />
+<add key="KCSyncWebRoot" value="[URL OF THE TARGET WEB SITE]" />
+<add key="KCSyncAssetsDomain" value="[KENTICO KONTENT ASSET DOMAIN]" />
+<add key="KCSyncProjectID" value="[YOUR PROJECT ID]" />
+<add key="KCSyncCMAPIKey" value="[YOUR CM API KEY]" />
 ```
 
 `KCSyncSitename` is the code name of the site you want to synchronize to Kentico Kontent, e.g. `DancingGoatMvc`
@@ -113,6 +113,25 @@ In case you would like to embrace fully headless CMS, migrate your content and c
 NOTE: The module synchronizes only published content. If you have any unpublished content that you wish to migrate, publish it before the data migration. 
 
 Continue with the editing in Kentico Kontent.
+
+### Development
+
+You can merge this repository with your existing Kentico EMS project and make commits to it provided it doesn't have it's own git repository.
+
+Follow the installation guide, but instead of cloning the repository to another folder and copying it over to your installation, clone it directly to your existing Kentico EMS installation.
+
+Run the following commands in command line:
+
+```
+cd your/kentico/ems/root/folder
+git init
+echo * > .gitignore
+git remote add origin https://github.com/Kentico/ems-module-kontent-publishing.git
+git fetch
+git checkout origin/master -b master
+```
+
+After this, you can easily edit the code, and commit changes to the original repository. Feel free to submit any pull requests with fixed or enhanced functionality.
 
 ### Module uninstallation
 

--- a/README.md
+++ b/README.md
@@ -147,4 +147,8 @@ Rebuild the solution(s).
 
 ![Analytics](https://kentico-ga-beacon.azurewebsites.net/api/UA-69014260-4/Kentico/ems-module-kontent-publishing?pixel)
 
+### Known issues
+
+Field type changes which would change the element type in the Kontent content type are not supported. E.g. changing number to text.
+
 ## [Questions & Support](https://github.com/Kentico/Home/blob/master/README.md)

--- a/README.md
+++ b/README.md
@@ -46,10 +46,6 @@ OPTIONAL: In case you have more projects, e.g. an MVC site instance, add the sam
 
 Create a **new empty project** in [Kentico Kontent](https://app.kontent.ai).
 
-Navigate to **Project settings** then to **Localization** and define all the languages that your site in Kentico EMS uses.
-
-NOTE: The languages in Kentico Kontent must use the same code names (case sensitive) as Kentico EMS. You can find their code names in **Kentico EMS administration** when you navigate to **Localization** and then to **Cultures**.
-
 Add the following keys to the web.config (or app.config) of your project(s)
 
 ```


### PR DESCRIPTION
### Motivation

After finalizing contract of Kontent Management API, some things didn't work properly, namely:
* Taxonomy listing model has changes, so the module wasn't able to read and delete taxonomies
* Patch operations for content types and were missing the `path` property in individual operations
* Parts of the the code were still referring to Kentico Cloud product name instead of Kontent
* It used the old management API domain

In addition to fixes:
* Content of the pages is now organized into content groups
* Elements and other synchronized objects now display names, code names are just as before (through editable code names)
* Elements now include explanation text in their guidelines
* Form groups are now added as Guidelines headings to visually separate fields on the Content tab in Kontent

### How to test

Test complete synchronization according to readme. Test the synchronization again (over existing data). Test deleting of all objects in Kontent. All should work according the readme.